### PR TITLE
Throw errors on module failure. Also update docs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,3 +27,10 @@ jobs:
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          build_args:
+            - '--no-build-vignettes'
+          args:
+            - '--no-examples'
+            - '--no-vignettes'
+            - '--no-tests'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,4 +29,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           build_args: '"--no-build-vignettes"'
-          args: 'c("--no-examples", "--no-vignettes", "--no-tests", "--no-manual")'
+          args: 'c("--no-examples", "--no-vignettes", "--no-tests", "--no-manual", "--ignore-vignettes")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,9 +28,5 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          build_args:
-            - '--no-build-vignettes'
-          args:
-            - '--no-examples'
-            - '--no-vignettes'
-            - '--no-tests'
+          build_args: '"--no-build-vignettes"'
+          args: 'c("--no-examples", "--no-vignettes", "--no-tests")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,4 +29,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           build_args: '"--no-build-vignettes"'
-          args: 'c("--no-examples", "--no-vignettes", "--no-tests")'
+          args: 'c("--no-examples", "--no-vignettes", "--no-tests", "--no-manual")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
+Depends: R (>= 4.2.0)
 Imports: 
     cli,
     withr
@@ -23,7 +24,6 @@ Suggests:
     testthat (>= 3.0.0),
     pkgdown,
     remotes,
-    rprojroot
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 License: GPL (>= 3)

--- a/R/completions.R
+++ b/R/completions.R
@@ -6,6 +6,7 @@ NULL
 #' Get autocompletions for [module_load()]
 #' @param x The `module_load` function
 #' @param pattern Ignored
+#' @keywords autocomplete
 #' @return A character vector of available modules
 #' @export
 .DollarNames.module_load = function(x, pattern){
@@ -15,6 +16,7 @@ NULL
 #' Calls a function using the name used after the dollar sign
 #' @param x The function to call
 #' @param name The name to pass in to the function
+#' @keywords autocomplete
 #' @return The return value of `x`
 #' @export
 `$.dollar_function` = function(x, name){
@@ -24,6 +26,7 @@ NULL
 #' Get autocompletions for [module_unload()]
 #' @param x The `module_unload` function
 #' @param pattern Ignored
+#' @keywords autocomplete
 #' @return A character vector of currently-loaded modules
 #' @export
 .DollarNames.module_unload = function(x, pattern){

--- a/R/high_level.R
+++ b/R/high_level.R
@@ -1,5 +1,8 @@
 # High level, user-friendly functions
 
+# Used to silence R CMD check
+mlstatus <- NULL
+
 #' Loads one or more environment modules
 #' @param ... Any number of modules to load as character vectors, which will
 #' all be concatenated together.
@@ -22,7 +25,7 @@ module_load = structure(
         cli::cli_alert_success("Successfully loaded {modules}")
       }
       else {
-        cli::abort("Failed to load {modules}")
+        cli::cli_abort("Failed to load {modules}")
       }
     }
     invisible(NULL)
@@ -52,7 +55,7 @@ module_unload = structure(
         cli::cli_alert_success("Successfully unloaded {modules}")
       }
       else {
-        cli::abort("Failed to unload {modules}")
+        cli::cli_abort("Failed to unload {modules}")
       }
     }
     invisible(TRUE)
@@ -108,7 +111,7 @@ module_purge = function(){
       cli::cli_alert_success("Successfully purged modules")
     }
     else {
-      cli::abort("Failed to purge modules")
+      cli::cli_abort("Failed to purge modules")
     }
   }
   invisible(NULL)

--- a/R/high_level.R
+++ b/R/high_level.R
@@ -18,9 +18,14 @@ module_load = structure(
     }
     else {
       eval(code)
-      cli::cli_alert_success("Successfully loaded {modules}")
+      if (mlstatus){
+        cli::cli_alert_success("Successfully loaded {modules}")
+      }
+      else {
+        cli::abort("Failed to load {modules}")
+      }
     }
-    invisible(TRUE)
+    invisible(NULL)
   },
   class = c("module_load", "dollar_function", "function")
 )
@@ -43,7 +48,12 @@ module_unload = structure(
     }
     else {
       eval(code)
-      cli::cli_alert_success("Successfully unloaded {modules}")
+      if (mlstatus){
+        cli::cli_alert_success("Successfully unloaded {modules}")
+      }
+      else {
+        cli::abort("Failed to unload {modules}")
+      }
     }
     invisible(TRUE)
   },
@@ -87,8 +97,21 @@ module_avail = function(filter = ""){
 #' @examples
 #' module_purge()
 module_purge = function(){
-  get_module_code("purge") |> eval()
-  invisible(TRUE)
+  code = get_module_code("purge")
+
+  if (length(code) == 0){
+    cli::cli_alert_info("Nothing to do. Most likely no modules were loaded.")
+  }
+  else {
+    eval(code)
+    if (mlstatus){
+      cli::cli_alert_success("Successfully purged modules")
+    }
+    else {
+      cli::abort("Failed to purge modules")
+    }
+  }
+  invisible(NULL)
 }
 
 #' Unloads one module, and loads a second module.

--- a/R/with.R
+++ b/R/with.R
@@ -10,8 +10,11 @@
 #' the LDFLAGS environment variable in your Makevars file. It will not work
 #' if the R package is not set up to correctly use LDFLAGS, but all
 #' correctly configured R packages will automatically do so.
-#' Also, it is recommended that you have only the minimal number of modules
+#' It is recommended that you have only the minimal number of modules
 #' needed to install this package loaded when you run this.
+#' It is also recommended that you use [utils::install.packages()] with the
+#' `utils` namespace qualifier, because RStudio patches this function in an
+#' incompatible way.
 #' @param expr Any R code you want to run that installs packages. Most of the
 #' time this will just be a call to [install.packages]()
 #' @return The result of evaluating `expr`
@@ -20,7 +23,7 @@
 #' @examples
 #' options(repos=c(CRAN="https://cloud.r-project.org/"))
 #' module_load("hdf5")
-#' install.packages("hdf5r") |> with_module_install()
+#' utils::install.packages("hdf5r") |> with_module_install()
 with_module_install = function(expr){
   withr::with_makevars(
     c(LDFLAGS=paste0("-Wl,-rpath,", Sys.getenv("LD_LIBRARY_PATH"))),

--- a/README.md
+++ b/README.md
@@ -25,26 +25,26 @@ You can list the available modules:
 
 ``` r
 module_avail()
-#>   [1] "7zip/15.14.1"                            "adxv/1.9.12"                             "alphafold/2.0.0"                         "alphafold/2.0.1"                        
-#>   [5] "alphafold/2.0.2"                         "alphafold/2.1.1.0"                       "alphafold/2.1.2.0"                       "alphafold/2.2.0.0"                      
-#>   [9] "anaconda3/2019.03"                       "anaconda3/2020.07"                       "anaconda3/4.0.0"                         "anaconda3/4.3.1"                        
-#>  [13] "anaconda3/latest"                        "annovar/2015-12-14"                      "apache-ant/1.9.7"                        "apptainer/1.0.0"                        
-#>  [17] "apptainer/1.1.0"                         "aspera/3.5.4"                            "aspera/3.9.1"                            "aspera/3.9.6"                           
-#>  [21] "autoPROC/20211020"                       "autoPROC/20220608"                       "autoPROC/20230217"                       "autoSHARP/2.8"                          
-#>  [25] "awscli/1.16py2.7"                        "awscli/1.16py3.7"                        "awscli/1.22.89"                          "awscli/2.1.25"                          
-#>  [29] "awscli/2.5.2"                            "axel/2.17.10"                            "bamtools/2.4.1"                          "bamUtil/1.0.14"                         
-#>  [33] "bazel/0.26.1"                            "bazel/1.2.1"                             "bcftools/1.12"                           "bcftools/1.13"                          
-#>  [37] "bcftools/1.14"                           "bcftools/1.15"                           "bcftools/1.16"                           "bcftools/1.17"                          
-#>  [41] "bcftools/1.3.1"                          "bcftools/1.6"                            "bcftools/1.7"                            "bcftools/1.9"                           
-#>  [45] "bcl-convert/3.10.5"                      "bcl-convert/3.9.3"                       "bcl2fastq/2.19.1"                        "bcl2fastq/2.20.0"                       
-#>  [49] "beast/1.8.3"                             "beast2/2.4.0"                            "bedops/2.4.26"                           "bedtools/2.25.0"                        
-#>  [53] "bedtools/2.26.0"                         "binutils/2.35.2-gcc-4.8.5"               "binutils/2.35.2-gcc-9.1.0"               "biobambam2/2.0.182-gcc9.1.0"            
-#>  [57] "bismark/0.16.1"                          "bismark/0.19.0"                          "bismark/0.19.1"                          "bismark/0.20.0"                         
-#>  [61] "boost/1.55.0"                            "boost/1.58.0"                            "boost/1.60.0"                            "boost/1.66.0"                           
-#>  [65] "bowtie/1.1.2"                            "bowtie2/2.2.9"                           "bowtie2/2.3.2"                           "bowtie2/2.3.4.1"                        
-#>  [69] "bowtie2/2.4.4"                           "bpipe/0.9.9.2"                           "breakdancer/1.1.2"                       "breakdancer/1.4.5"                      
-#>  [73] "bsoft/2.1.0"                             "buster/20211020"                         "buster/20220608"                         "bwa/0.7.13"                             
-#>  [77] "bwa/0.7.15"                              "bwa/0.7.17"                              "bwtool/1.0"                              "bzip2/1.0.6"                            
+#>   [1] "7zip/15.14.1"                            "adxv/1.9.12"                             "alphafold/2.0.0"                        
+#>   [4] "alphafold/2.0.1"                         "alphafold/2.0.2"                         "alphafold/2.1.1.0"                      
+#>   [7] "alphafold/2.1.2.0"                       "alphafold/2.2.0.0"                       "anaconda3/2019.03"                      
+#>  [10] "anaconda3/2020.07"                       "anaconda3/4.0.0"                         "anaconda3/4.3.1"                        
+#>  [13] "anaconda3/latest"                        "annovar/2015-12-14"                      "apache-ant/1.9.7"                       
+#>  [16] "apptainer/1.0.0"                         "apptainer/1.1.0"                         "aspera/3.5.4"                           
+#>  [19] "aspera/3.9.1"                            "aspera/3.9.6"                            "autoPROC/20211020"                      
+#>  [22] "autoPROC/20220608"                       "autoPROC/20230222"                       "autoSHARP/2.8"                          
+#>  [25] "awscli/1.16py2.7"                        "awscli/1.16py3.7"                        "awscli/1.22.89"                         
+#>  [28] "awscli/2.1.25"                           "awscli/2.5.2"                            "axel/2.17.10"                           
+#>  [31] "bamtools/2.4.1"                          "bamUtil/1.0.14"                          "bazel/0.26.1"                           
+#>  [34] "bazel/1.2.1"                             "bcftools/1.12"                           "bcftools/1.13"                          
+#>  [37] "bcftools/1.14"                           "bcftools/1.15"                           "bcftools/1.16"                          
+#>  [40] "bcftools/1.17"                           "bcftools/1.3.1"                          "bcftools/1.6"                           
+#>  [43] "bcftools/1.7"                            "bcftools/1.9"                            "bcl-convert/3.10.5"                     
+#>  [46] "bcl-convert/3.9.3"                       "bcl2fastq/2.19.1"                        "bcl2fastq/2.20.0"                       
+#>  [49] "beast/1.8.3"                             "beast2/2.4.0"                            "bedops/2.4.26"                          
+#>  [52] "bedtools/2.25.0"                         "bedtools/2.26.0"                         "binutils/2.35.2-gcc-4.8.5"              
+#>  [55] "binutils/2.35.2-gcc-9.1.0"               "biobambam2/2.0.182-gcc9.1.0"             "bismark/0.16.1"                         
+#>  [58] "bismark/0.19.0"                          "bismark/0.19.1"                          "bismark/0.20.0"                         
 ....
 ```
 
@@ -52,8 +52,8 @@ You can also easily filter to only modules containing a substring:
 
 ``` r
 module_avail("python")
-#>  [1] "python/2.7.18"      "python/3.10.4"      "python/3.5.1"       "python/3.5.3"       "python/3.6.5-intel" "python/3.7.0"       "python/3.7.13"      "python/3.8.3"      
-#>  [9] "python/3.8.8"       "python/3.9.5"
+#>  [1] "python/2.7.18"      "python/3.10.4"      "python/3.5.1"       "python/3.5.3"       "python/3.6.5-intel" "python/3.7.0"       "python/3.7.13"     
+#>  [8] "python/3.8.3"       "python/3.8.8"       "python/3.9.5"
 ```
 
 ## Loading and Unloading Modules
@@ -98,22 +98,12 @@ that activates if you put a dollar sign after the function name.
 For example, you can type `module_load$` and the following will appear
 in RStudio:
 
-``` r
-#rprojroot::find_package_root_file("vignettes", "rstudio_autocomplete.rng")  |> stop()
-#getwd() |> stop()
-
-xfun::from_root("vignettes", "rstudio_autocomplete.png") |>
-  knitr::include_graphics()
-```
-
 ![](vignettes/rstudio_autocomplete.png)<!-- -->
-
-![](vignettes/rstudio_autocomplete.png)
 
 This autocomplete will adjust as to type, to let you quickly filter down
 all the available modules:
 
-![](vignettes/rstudio_autocomplete_2.png)
+![](vignettes/rstudio_autocomplete_2.png)<!-- -->
 
 To actually load the module, just press enter:
 
@@ -144,7 +134,8 @@ need to find out what the module is called:
 
 ``` r
 module_avail("hdf5")
-#> [1] "hdf5-mpich/1.10.5_3.3" "hdf5/1.10.5"           "hdf5/1.12.1"           "hdf5/1.12.2"           "hdf5/1.8.16"           "hdf5/1.8.20"           "hdf5/1.8.21"
+#> [1] "hdf5-mpich/1.10.5_3.3" "hdf5/1.10.5"           "hdf5/1.12.1"           "hdf5/1.12.2"           "hdf5/1.8.16"           "hdf5/1.8.20"          
+#> [7] "hdf5/1.8.21"
 ```
 
 We can now load the module:
@@ -164,6 +155,9 @@ Finally, we can load the package itself… or can we?
 
 ``` r
 library(hdf5r)
+#> Error: package or namespace load failed for 'hdf5r' in dyn.load(file, DLLpath = DLLpath, ...):
+#>  unable to load shared object '/stornext/Home/data/allstaff/m/milton.m/R/x86_64-pc-linux-gnu-library/4.2/hdf5r/libs/hdf5r.so':
+#>   libhdf5_hl.so.200: cannot open shared object file: No such file or directory
 ```
 
 As alluded to above, R doesn’t actually load every new library that

--- a/README.md
+++ b/README.md
@@ -25,26 +25,26 @@ You can list the available modules:
 
 ``` r
 module_avail()
-#>   [1] "7zip/15.14.1"                            "adxv/1.9.12"                             "alphafold/2.0.0"                         "alphafold/2.0.1"                         "alphafold/2.0.2"                        
-#>   [6] "alphafold/2.1.1.0"                       "alphafold/2.1.2.0"                       "alphafold/2.2.0.0"                       "anaconda3/2019.03"                       "anaconda3/2020.07"                      
-#>  [11] "anaconda3/4.0.0"                         "anaconda3/4.3.1"                         "anaconda3/latest"                        "annovar/2015-12-14"                      "apache-ant/1.9.7"                       
-#>  [16] "apptainer/1.0.0"                         "apptainer/1.1.0"                         "aspera/3.5.4"                            "aspera/3.9.1"                            "aspera/3.9.6"                           
-#>  [21] "autoPROC/20211020"                       "autoPROC/20220608"                       "autoPROC/20230217"                       "autoSHARP/2.8"                           "awscli/1.16py2.7"                       
-#>  [26] "awscli/1.16py3.7"                        "awscli/1.22.89"                          "awscli/2.1.25"                           "awscli/2.5.2"                            "axel/2.17.10"                           
-#>  [31] "bamtools/2.4.1"                          "bamUtil/1.0.14"                          "bazel/0.26.1"                            "bazel/1.2.1"                             "bcftools/1.12"                          
-#>  [36] "bcftools/1.13"                           "bcftools/1.14"                           "bcftools/1.15"                           "bcftools/1.16"                           "bcftools/1.3.1"                         
-#>  [41] "bcftools/1.6"                            "bcftools/1.7"                            "bcftools/1.9"                            "bcl-convert/3.10.5"                      "bcl-convert/3.9.3"                      
-#>  [46] "bcl2fastq/2.19.1"                        "bcl2fastq/2.20.0"                        "beast/1.8.3"                             "beast2/2.4.0"                            "bedops/2.4.26"                          
-#>  [51] "bedtools/2.25.0"                         "bedtools/2.26.0"                         "binutils/2.35.2-gcc-4.8.5"               "binutils/2.35.2-gcc-9.1.0"               "biobambam2/2.0.182-gcc9.1.0"            
-#>  [56] "bismark/0.16.1"                          "bismark/0.19.0"                          "bismark/0.19.1"                          "bismark/0.20.0"                          "boost/1.55.0"                           
-#>  [61] "boost/1.58.0"                            "boost/1.60.0"                            "boost/1.66.0"                            "bowtie/1.1.2"                            "bowtie2/2.2.9"                          
-#>  [66] "bowtie2/2.3.2"                           "bowtie2/2.3.4.1"                         "bowtie2/2.4.4"                           "bpipe/0.9.9.2"                           "breakdancer/1.1.2"                      
-#>  [71] "breakdancer/1.4.5"                       "bsoft/2.1.0"                             "buster/20211020"                         "buster/20220608"                         "bwa/0.7.13"                             
-#>  [76] "bwa/0.7.15"                              "bwa/0.7.17"                              "bwtool/1.0"                              "bzip2/1.0.6"                             "caffe2/0.8.1"                           
-#>  [81] "canu/1.3"                                "canu/1.5"                                "ccp4/7.1"                                "ccp4/8.0"                                "ccpem/1.5.0"                            
-#>  [86] "cellprofiler/4.2.1"                      "cellprofiler/4.2.4"                      "cellranger-arc/1.0.1"                    "cellranger-arc/2.0.2"                    "cellranger-atac/1.0.0"                  
-#>  [91] "cellranger-atac/1.2.0"                   "cellranger-atac/2.1.0"                   "cellranger/2.2.0"                        "cellranger/3.0.1"                        "cellranger/3.0.2"                       
-#>  [96] "cellranger/3.1.0"                        "cellranger/4.0.0"                        "cellranger/5.0.0"                        "cellranger/6.0.0"                        "cellranger/6.1.2"                       
+#>   [1] "7zip/15.14.1"                            "adxv/1.9.12"                             "alphafold/2.0.0"                         "alphafold/2.0.1"                        
+#>   [5] "alphafold/2.0.2"                         "alphafold/2.1.1.0"                       "alphafold/2.1.2.0"                       "alphafold/2.2.0.0"                      
+#>   [9] "anaconda3/2019.03"                       "anaconda3/2020.07"                       "anaconda3/4.0.0"                         "anaconda3/4.3.1"                        
+#>  [13] "anaconda3/latest"                        "annovar/2015-12-14"                      "apache-ant/1.9.7"                        "apptainer/1.0.0"                        
+#>  [17] "apptainer/1.1.0"                         "aspera/3.5.4"                            "aspera/3.9.1"                            "aspera/3.9.6"                           
+#>  [21] "autoPROC/20211020"                       "autoPROC/20220608"                       "autoPROC/20230217"                       "autoSHARP/2.8"                          
+#>  [25] "awscli/1.16py2.7"                        "awscli/1.16py3.7"                        "awscli/1.22.89"                          "awscli/2.1.25"                          
+#>  [29] "awscli/2.5.2"                            "axel/2.17.10"                            "bamtools/2.4.1"                          "bamUtil/1.0.14"                         
+#>  [33] "bazel/0.26.1"                            "bazel/1.2.1"                             "bcftools/1.12"                           "bcftools/1.13"                          
+#>  [37] "bcftools/1.14"                           "bcftools/1.15"                           "bcftools/1.16"                           "bcftools/1.17"                          
+#>  [41] "bcftools/1.3.1"                          "bcftools/1.6"                            "bcftools/1.7"                            "bcftools/1.9"                           
+#>  [45] "bcl-convert/3.10.5"                      "bcl-convert/3.9.3"                       "bcl2fastq/2.19.1"                        "bcl2fastq/2.20.0"                       
+#>  [49] "beast/1.8.3"                             "beast2/2.4.0"                            "bedops/2.4.26"                           "bedtools/2.25.0"                        
+#>  [53] "bedtools/2.26.0"                         "binutils/2.35.2-gcc-4.8.5"               "binutils/2.35.2-gcc-9.1.0"               "biobambam2/2.0.182-gcc9.1.0"            
+#>  [57] "bismark/0.16.1"                          "bismark/0.19.0"                          "bismark/0.19.1"                          "bismark/0.20.0"                         
+#>  [61] "boost/1.55.0"                            "boost/1.58.0"                            "boost/1.60.0"                            "boost/1.66.0"                           
+#>  [65] "bowtie/1.1.2"                            "bowtie2/2.2.9"                           "bowtie2/2.3.2"                           "bowtie2/2.3.4.1"                        
+#>  [69] "bowtie2/2.4.4"                           "bpipe/0.9.9.2"                           "breakdancer/1.1.2"                       "breakdancer/1.4.5"                      
+#>  [73] "bsoft/2.1.0"                             "buster/20211020"                         "buster/20220608"                         "bwa/0.7.13"                             
+#>  [77] "bwa/0.7.15"                              "bwa/0.7.17"                              "bwtool/1.0"                              "bzip2/1.0.6"                            
 ....
 ```
 
@@ -52,7 +52,8 @@ You can also easily filter to only modules containing a substring:
 
 ``` r
 module_avail("python")
-#>  [1] "python/2.7.18"      "python/3.10.4"      "python/3.5.1"       "python/3.5.3"       "python/3.6.5-intel" "python/3.7.0"       "python/3.7.13"      "python/3.8.3"       "python/3.8.8"       "python/3.9.5"
+#>  [1] "python/2.7.18"      "python/3.10.4"      "python/3.5.1"       "python/3.5.3"       "python/3.6.5-intel" "python/3.7.0"       "python/3.7.13"      "python/3.8.3"      
+#>  [9] "python/3.8.8"       "python/3.9.5"
 ```
 
 ## Loading and Unloading Modules
@@ -96,6 +97,16 @@ that activates if you put a dollar sign after the function name.
 
 For example, you can type `module_load$` and the following will appear
 in RStudio:
+
+``` r
+#rprojroot::find_package_root_file("vignettes", "rstudio_autocomplete.rng")  |> stop()
+#getwd() |> stop()
+
+xfun::from_root("vignettes", "rstudio_autocomplete.png") |>
+  knitr::include_graphics()
+```
+
+![](vignettes/rstudio_autocomplete.png)<!-- -->
 
 ![](vignettes/rstudio_autocomplete.png)
 
@@ -153,9 +164,6 @@ Finally, we can load the package itself… or can we?
 
 ``` r
 library(hdf5r)
-#> Error: package or namespace load failed for 'hdf5r' in dyn.load(file, DLLpath = DLLpath, ...):
-#>  unable to load shared object '/stornext/Home/data/allstaff/m/milton.m/R/x86_64-pc-linux-gnu-library/4.2/hdf5r/libs/hdf5r.so':
-#>   libhdf5_hl.so.200: cannot open shared object file: No such file or directory
 ```
 
 As alluded to above, R doesn’t actually load every new library that

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -12,6 +12,10 @@ reference:
   desc: "withr-style functions that run R code in a certain module environment"
   contents:
   - has_keyword("with")
+- title: "Autocomplete"
+  desc: 'Machinery that powers the "magic autocomplete"'
+  contents:
+  - has_keyword("autocomplete")
 - title: "Advanced Functions"
   desc: "Powerful, but more complex functions you are less likely to need"
   contents:

--- a/man/cash-.dollar_function.Rd
+++ b/man/cash-.dollar_function.Rd
@@ -17,3 +17,4 @@ The return value of \code{x}
 \description{
 Calls a function using the name used after the dollar sign
 }
+\keyword{autocomplete}

--- a/man/dot-DollarNames.module_load.Rd
+++ b/man/dot-DollarNames.module_load.Rd
@@ -17,3 +17,4 @@ A character vector of available modules
 \description{
 Get autocompletions for \code{\link[=module_load]{module_load()}}
 }
+\keyword{autocomplete}

--- a/man/dot-DollarNames.module_unload.Rd
+++ b/man/dot-DollarNames.module_unload.Rd
@@ -17,3 +17,4 @@ A character vector of currently-loaded modules
 \description{
 Get autocompletions for \code{\link[=module_unload]{module_unload()}}
 }
+\keyword{autocomplete}

--- a/man/with_module_install.Rd
+++ b/man/with_module_install.Rd
@@ -25,12 +25,15 @@ This functionality is performed by setting a temporary value of
 the LDFLAGS environment variable in your Makevars file. It will not work
 if the R package is not set up to correctly use LDFLAGS, but all
 correctly configured R packages will automatically do so.
-Also, it is recommended that you have only the minimal number of modules
+It is recommended that you have only the minimal number of modules
 needed to install this package loaded when you run this.
+It is also recommended that you use \code{\link[utils:install.packages]{utils::install.packages()}} with the
+\code{utils} namespace qualifier, because RStudio patches this function in an
+incompatible way.
 }
 \examples{
 options(repos=c(CRAN="https://cloud.r-project.org/"))
 module_load("hdf5")
-install.packages("hdf5r") |> with_module_install()
+utils::install.packages("hdf5r") |> with_module_install()
 }
 \keyword{with}

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -113,5 +113,5 @@ test_that("module_avail() works", {
 test_that("module_load() throws an error on failure", {
   check_wehi()
 
-  module_load("NOT_A_REAL_MODULE") |> expect_error()
+  module_load("NOT_A_REAL_MODULE") |> expect_error("Failed to load")
 })

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -109,3 +109,9 @@ test_that("module_avail() works", {
 
   module_avail() |> length() |> expect_gt(500)
 })
+
+test_that("module_load() throws an error on failure", {
+  check_wehi()
+
+  module_load("NOT_A_REAL_MODULE") |> expect_error()
+})

--- a/vignettes/README.Rmd
+++ b/vignettes/README.Rmd
@@ -34,7 +34,7 @@ process_ansi_string = function(x, options) {
 knit_print.cliMessage = process_ansi_string
 knit_print.ansi_string = process_ansi_string
 
-knitr::opts_knit$set(root.dir = rprojroot::find_package_root_file())
+knitr::opts_knit$set(root.dir = xfun::proj_root())
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", eval = requireNamespace("pkgdown") && !pkgdown::in_pkgdown())
 hook_output <- knitr::knit_hooks$get("output")
 knitr::knit_hooks$set(output = function(x, options) {
@@ -121,11 +121,17 @@ Both `module_load` and `module_unload` support a "magic" autocomplete that activ
 
 For example, you can type `module_load$` and the following will appear in RStudio:
 
-![](vignettes/rstudio_autocomplete.png)
+```{r, echo=FALSE}
+xfun::from_root("vignettes", "rstudio_autocomplete.png") |>
+  knitr::include_graphics()
+```
 
 This autocomplete will adjust as to type, to let you quickly filter down all the available modules:
 
-![](vignettes/rstudio_autocomplete_2.png)
+```{r, echo=FALSE}
+xfun::from_root("vignettes", "rstudio_autocomplete_2.png") |>
+  knitr::include_graphics()
+```
 
 To actually load the module, just press enter:
 


### PR DESCRIPTION
* `module_load("NONEXISTENT")` will now throw an error (closes #7)
* Enforce R > 4.2 due to the use of native pipes
* Regenerate readme
* Add documentation for autocomplete methods